### PR TITLE
updated makefile to build libraries

### DIFF
--- a/makefile
+++ b/makefile
@@ -171,19 +171,19 @@ vpath %.cpp $(sort $(dir $(CPP_SOURCES)))
 OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(ASM_SOURCES:.s=.o)))
 vpath %.s $(sort $(dir $(ASM_SOURCES)))
 
-$(BUILD_DIR)/%.o: %.c makefile | $(BUILD_DIR) 
+$(BUILD_DIR)/%.o: %.c | $(BUILD_DIR) 
 	$(CC) -c $(CFLAGS) -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.c=.lst)) $< -o $@
 	@echo ""
 
-$(BUILD_DIR)/%.o: %.cpp makefile | $(BUILD_DIR) 
+$(BUILD_DIR)/%.o: %.cpp | $(BUILD_DIR) 
 	$(CPP_CC) -c $(CFLAGS) -Wa,-a,-ad,-alms=$(BUILD_DIR)/$(notdir $(<:.cpp=.lst)) $< -o $@
 	@echo ""
 
-$(BUILD_DIR)/%.o: %.s makefile | $(BUILD_DIR)
+$(BUILD_DIR)/%.o: %.s | $(BUILD_DIR)
 	$(AS) -c $(CFLAGS) $< -o $@
 	@echo ""
 
-$(BUILD_DIR)/$(TARGET).elf: $(OBJECTS) makefile
+$(BUILD_DIR)/$(TARGET).elf: $(OBJECTS) | libs
 	$(CPP_CC) $(OBJECTS) ./WLoopCAN/bin/wloop_can.a ./WLoopUtil/bin/wloop_util.a $(LDFLAGS) -o $@
 	@echo ""
 	$(SZ) $@
@@ -196,13 +196,19 @@ $(BUILD_DIR)/%.bin: $(BUILD_DIR)/%.elf | $(BUILD_DIR)
 	$(BIN) $< $@	
 	
 $(BUILD_DIR):
-	mkdir $@		
+	mkdir $@
+
+libs:
+	cd WLoopCAN && make master_bms
+	cd WLoopUtil && make master_bms
 
 #######################################
 # clean up
 #######################################
 clean:
 	rm -rf $(BUILD_DIR)
+	rm -rf ./WLoopCAN/bin
+	rm -rf ./WLoopUtil/bin
 
 analyze:
 	$(PREFIX)objdump -t $(BUILD_DIR)/$(TARGET).elf

--- a/makefile
+++ b/makefile
@@ -18,6 +18,8 @@ TARGET = main
 DEVICE_DIRNAME = STM32F405RGTx
 # DEVICE_DIRNAME = STM32F401RETx
 
+BOARD = master_bms
+
 ######################################
 # building variables
 ######################################
@@ -199,8 +201,8 @@ $(BUILD_DIR):
 	mkdir $@
 
 libs:
-	cd WLoopCAN && make master_bms
-	cd WLoopUtil && make master_bms
+	cd WLoopCAN && make $(BOARD)
+	cd WLoopUtil && make $(BOARD)
 
 #######################################
 # clean up


### PR DESCRIPTION
As we add new libraries and submodules, it will get annoying to have to build all of them manually. This change will build the libraries automatically when you run `make` in the main project directory.