### PR TITLE
BMS_SW_G5 BMS CLI

### DIFF
--- a/STM32F405RGTx/Core/Inc/bist_thread.hpp
+++ b/STM32F405RGTx/Core/Inc/bist_thread.hpp
@@ -32,6 +32,7 @@ class BistThread {
 
         // help
         static void _help();
+
         // print measurements
         static void _p_measurements();
 
@@ -43,5 +44,13 @@ class BistThread {
 
         // clears the command interface
         static void _clear();
-};
 
+        // changes bms state
+        static void _bms_state();
+
+        // help for state commands
+        static void _help_state();
+
+        // switches off the contactor
+        static void _toggle_cont();
+};


### PR DESCRIPTION
1. Add a new "mode" for the CLI, call it an "admin" mode or "priveleged" mode or something
a. This mode should be off by default
b. Only when the CLI is in this mode, will a user be able to use the below features
2. Add a command to transition the BMS state in the state machine
    These commands should be sanitized so that an invalid transition cannot be made by the user
3. Add a command to manually switch OFF the contactor